### PR TITLE
3: Add notification on limit reach

### DIFF
--- a/src/components/charts/wallet/budget/editBudget.js
+++ b/src/components/charts/wallet/budget/editBudget.js
@@ -34,6 +34,14 @@ class EditBudgetMode extends Component {
     onHandleSave = (data,id) => {
         this.props.dispatch(updateBudget(data, id));
         this.props.onEditBudgetHandle();
+        // Show alert when the budget category exceeds 100%.
+
+        let total = 0;
+        this.props.items.filter(item => item.category === this.state.category).forEach(item => total += item.amount);
+        total = total *  100 / this.state.amount;
+        if (total >= 100) {
+            alert(`The budget ${this.state.category} exceed 100% of its capacity.`);
+        }
     };
 
     render() {
@@ -87,4 +95,6 @@ class EditBudgetMode extends Component {
     }
 }
 
-export default connect()(EditBudgetMode);
+const mapStateToProps = state => ({ items: state.budgetReducer });
+
+export default connect(mapStateToProps)(EditBudgetMode);

--- a/src/components/newExpense/index.js
+++ b/src/components/newExpense/index.js
@@ -12,7 +12,7 @@ class NewBudget extends Component {
     id: uuid(),
     name: "",
     amount: 0,
-    date: "",
+    date: new Date().toISOString().slice(0, 10),
     category: "",
     notes: "",
     nameError: "",
@@ -66,10 +66,16 @@ class NewBudget extends Component {
       this.props.dispatch(addNewBudget(newExpense));
       this.props.onCreateBudget();
     }
+    
+    // Show alert when the budget category exceeds 100%.
+    let total = 0;
+    this.props.items.filter(item => item.category === this.state.category).forEach(item => total += item.amount);
+    total = total *  100 / this.state.amount;
+    if (total >= 100) {
+      alert(`The budget ${this.state.category} exceed 100% of its capacity.`);
+    }
   };
-  dateDefaultVal = () => {
-    return new Date().toISOString().slice(0, 10);
-  }
+
   render() {
     return (
       <div className="ext-budget">
@@ -103,7 +109,7 @@ class NewBudget extends Component {
                 <input
                   type="date"
                   name="date"
-                  defaultValue={this.dateDefaultVal()}
+                  defaultValue={this.state.date}
                   onChange={e => this.onHandleChange(e)}
                 />
                 <div className="error">{this.state.dateError}</div>
@@ -125,4 +131,6 @@ class NewBudget extends Component {
   }
 }
 
-export default connect()(NewBudget);
+const mapStateToProps = state => ({ items: state.budgetReducer });
+
+export default connect(mapStateToProps)(NewBudget);


### PR DESCRIPTION
Add the following changes:

1. Native browser notification when the budget limit is reached. This happens both when the budget limit is edited OR when a new expense is added.
2. Fixes the bug in which even with a default date, the app would give an error to the user.

<img width="1072" alt="Screen Shot 2019-09-29 at 1 37 13 PM" src="https://user-images.githubusercontent.com/22270042/65836758-03641680-e2c0-11e9-9698-171cd074ada8.png">
